### PR TITLE
fixing https js link problem

### DIFF
--- a/index.html
+++ b/index.html
@@ -173,7 +173,7 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
 
 <!-- Custom .js -->
-<script src="Assets/javascript/code.js"></script>  
+<script src="./assets/javascript/code.js"></script>  
   
 </body>
 </html>


### PR DESCRIPTION
updated from:
<script src="Assets/javascript/code.js">
to
<script src="./assets/javascript/code.js">
to correct 404 on code.js when running through SSL.